### PR TITLE
Minimal working docker-compose dev setup

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,0 +1,18 @@
+# Using docker and docker-compose for local development
+
+```sh
+docker-compose build
+docker-compose run app python manage.py migrate
+docker-compose up
+```
+
+A server will now be running at `http://localhost:8080`.
+
+You will need to `docker-compose build` whenever `requirements.txt` changes since the dependencies are installed in the docker image (see `Dockerfile`).
+
+Note that in `docker-compose.yml`, `app` is the name of the service for the Django application, and `db` is the name of the database service. You can run any command within those service containers using `docker-compose run <SERVICE NAME> <COMMAND>`.
+
+For example:
+
+- `docker-compose run app py.test` will run the test suite.
+- `docker-compose run db bash` will get you a shell in the `db` container.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.6
+
+ENV PYTHONUNBUFFERED 1
+ENV PORT 80
+
+# Note that we want postgresql-client so 'manage.py dbshell' works.
+RUN apt-get update && apt-get install -y postgresql-client
+
+RUN mkdir /app
+WORKDIR /app
+
+ADD requirements.txt /app/
+RUN pip install -r requirements.txt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '2'
+services:
+  app:
+    build:
+      context: .
+    ports:
+      - 8080:8080
+    links:
+      - db
+    command: python manage.py runserver 0.0.0.0:8080
+    volumes:
+      - .:/app
+    environment:
+      - DJANGO_SECRET_KEY=development_secret_key
+      - DATABASE_URL=postgres://talentmap-user@db/talentmap
+  db:
+    image: postgres:9.6.3
+    volumes:
+      - pgdata:/var/lib/postgresql/data/
+    environment:
+      - POSTGRES_DB=talentmap
+      - POSTGRES_USER=talentmap-user
+volumes:
+  pgdata:


### PR DESCRIPTION
This PR contains the setup for a minimally functional docker-compose dev setup.

Upon first use after `docker-compose build`, you might get an error that the app is not able to connect to the database (something like `File "/usr/local/lib/python3.6/site-packages/django/db/backends/base/base.py", line 213, in ensure_connection self.connect()`).  This is because the postgres service hasn't completely finished starting up when the Django app tries to connect to it. You could add some additional wait logic as in https://github.com/18F/calc/blob/develop/docker_django_management.py#L162 to mitigate this issue.

