### PR TITLE
Clarify DJANGO_DEBUG setting; add to docker-compose env

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -50,7 +50,7 @@ The virtual environment has now been created. For further convenience, one can u
 To run the Django server, the following environment variables must be set:
 
 * `DJANGO_SECRET_KEY` - This should be any valid secret string. See the [Django documentation](https://docs.djangoproject.com/en/1.11/ref/settings/#std:setting-SECRET_KEY) for more information.
-* `DJANGO_DEBUG` - This should be set to `false` when in production, but will default to `true` if otherwise unset.
+* `DJANGO_DEBUG` - Set to `true` to run Django in Debug mode, which is helpful for development. It will default to `false`.
 
 #### Installing Requirements
 To install requirements, execute:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,15 +4,18 @@ services:
     build:
       context: .
     ports:
-      - 8080:8080
+      - 8000:8000
     links:
       - db
-    command: python manage.py runserver 0.0.0.0:8080
+    depends_on:
+      - db
+    command: python manage.py runserver 0.0.0.0:8000
     volumes:
       - .:/app
     environment:
       - DJANGO_SECRET_KEY=development_secret_key
       - DATABASE_URL=postgres://talentmap-user@db/talentmap
+      - DJANGO_DEBUG=true
   db:
     image: postgres:9.6.3
     volumes:


### PR DESCRIPTION
The docs for `DJANGO_DEBUG` had the inverse of that setting's default value. This PR is a correction to the documentation and also adds `DJANGO_DEBUG=true` to docker-compose.yml so that the dockerized app will run in debug mode.

also:
- use port 8000 in docker-compose to mirror native setup
- add `db` to `depends_on section` of web app in docker-compose