### PR TITLE
Remove spurious PORT env var

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM python:3.6
 
 ENV PYTHONUNBUFFERED 1
-ENV PORT 80
 
 # Note that we want postgresql-client so 'manage.py dbshell' works.
 RUN apt-get update && apt-get install -y postgresql-client


### PR DESCRIPTION
No reason to set `PORT` in the Dockerfile.