### PR TITLE
Share endpoint

### DIFF
--- a/talentmap_api/common/management/commands/load_xml.py
+++ b/talentmap_api/common/management/commands/load_xml.py
@@ -175,8 +175,8 @@ def mode_tour_of_duty():
     collision_field = "code"
     tag_map = {
         "TOUR_OF_DUTIES:TOD_CODE": "code",
-        "TOUR_OF_DUTIES:TOD_DESC_TEXT": "short_description",
-        "TOUR_OF_DUTIES:TOD_SHORT_DESC": lambda instance, item: setattr(instance, "long_description", re.sub('&amp;', '&', item.text).strip()),
+        "TOUR_OF_DUTIES:TOD_SHORT_DESC": "short_description",
+        "TOUR_OF_DUTIES:TOD_DESC_TEXT": lambda instance, item: setattr(instance, "long_description", re.sub('&amp;', '&', item.text).strip()),
         "TOUR_OF_DUTIES:TOD_MONTHS_NUM": "months"
     }
 

--- a/talentmap_api/common/tests/test_sharing.py
+++ b/talentmap_api/common/tests/test_sharing.py
@@ -1,0 +1,33 @@
+import pytest
+
+from model_mommy import mommy
+from model_mommy.recipe import Recipe
+from rest_framework import status
+
+
+@pytest.fixture
+def test_sharing_fixture():
+    mommy.make('position.Position', id=2)
+
+
+@pytest.mark.django_db()
+@pytest.mark.parametrize("payload, resp", [
+    ({}, status.HTTP_400_BAD_REQUEST),
+    ({"mode": "banana"}, status.HTTP_400_BAD_REQUEST),
+    ({"mode": "email"}, status.HTTP_400_BAD_REQUEST),
+    ({"mode": "email", "email": "a@a.c"}, status.HTTP_400_BAD_REQUEST),
+    ({"mode": "email", "type": "position"}, status.HTTP_400_BAD_REQUEST),
+    ({"mode": "email", "type": "position", "id": 1}, status.HTTP_400_BAD_REQUEST),
+    ({"mode": "email", "email": "a@a.c", "type": "banana"}, status.HTTP_400_BAD_REQUEST),
+    ({"mode": "email", "email": "a@a.c", "type": "position", "id": 1}, status.HTTP_404_NOT_FOUND),
+    ({"mode": "email", "email": "a@a.c", "type": "position", "id": 2}, status.HTTP_202_ACCEPTED),
+    ({"mode": "internal"}, status.HTTP_400_BAD_REQUEST),
+    ({"mode": "internal", "user": "a@a.c"}, status.HTTP_400_BAD_REQUEST),
+    ({"mode": "internal", "id": 1, "type": "position"}, status.HTTP_400_BAD_REQUEST),
+    ({"mode": "internal", "user": "a@a.c", "type": "position", "id": 1}, status.HTTP_501_NOT_IMPLEMENTED),
+])
+@pytest.mark.usefixtures("test_sharing_fixture")
+def test_payload_validation(client, payload, resp):
+    response = client.post("/api/v1/share/", payload)
+
+    assert response.status_code == resp

--- a/talentmap_api/common/views.py
+++ b/talentmap_api/common/views.py
@@ -1,0 +1,105 @@
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework import status
+
+from django.core.exceptions import ObjectDoesNotExist
+
+from talentmap_api.position.models import Position
+
+
+class ShareView(APIView):
+    '''
+    Shares a TalentMAP element
+
+    Post method accepts an object with at minimum the following parameters:
+    * type - the type of object to be shared (position)
+    * mode - the mode of sharing (internal, email)
+    * id - the id of the object to be shared
+    * email - the email to send the share to, if mode is email
+    * user - the user id to share the item with, if mode is internal
+    '''
+
+    AVAILABLE_MODES = ["email", "internal"]
+    AVAILABLE_TYPES = {
+        "position": Position
+    }
+
+    def post(self, request, format=None):
+        valid, error = self.validate(request)
+
+        if valid:
+            response = None
+            if request.data.get("mode") == "email":
+                response = self.email_share(request.data.get("email"), request.data.get("type"), request.data.get("id"))
+            elif request.data.get("mode") == "internal":
+                response = self.internal_share(request.data.get("user"), request.data.get("type"), request.data.get("id"))
+            return response
+        else:
+            return Response({"message": error}, status=status.HTTP_400_BAD_REQUEST)
+
+    def validate(self, request):
+        '''
+        Validates that the request is a properly formatted share request, returning (True, None) in that case.
+        If the request fails validation, it will return (False, String) where the second item of the tuple is
+        a string explanation of the validation error.
+        '''
+        if "mode" not in request.data:
+            return (False, "POSTs to this endpoint require the mode parameter")
+        elif request.data.get("mode") not in self.AVAILABLE_MODES:
+            return (False, f"Mode must be one of the following: {','.join(self.AVAILABLE_MODES)}")
+
+        if "type" not in request.data:
+            return (False, "POSTs to this endpoint require the type parameter")
+        elif request.data.get("type") not in self.AVAILABLE_TYPES.keys():
+            return (False, f"Type must be one of the following: {','.join(self.AVAILABLE_TYPES.keys())}")
+
+        if "id" not in request.data:
+            return (False, "id of sharable object must be specified")
+
+        # E-mail specific validations
+        if request.data.get("mode") == "email":
+            if "email" not in request.data:
+                return (False, "E-mail shares require an 'email' parameter to be specified")
+
+        # Internal specific validations
+        if request.data.get("mode") == "internal":
+            if "user" not in request.data:
+                return (False, "Internal shares require a 'user' parameter to be specified")
+
+        return (True, None)
+
+    def email_share(self, email, type, id):
+        # Get our e-mail formatter
+        formatter = self.get_email_formatter(type)
+        instance = None
+
+        # Attempt to get the object instance we want to share
+        try:
+            instance = self.AVAILABLE_TYPES[type].objects.get(id=id)
+        except ObjectDoesNotExist:
+            # If it doesn't exist, respond with a 404
+            return Response({"message": f"Object with id {id} does not exist"}, status=status.HTTP_404_NOT_FOUND)
+
+        # Create our e-mail body
+        email_body = {
+            "to": email,
+            "subject": f"[TalentMAP] Shared {type}",
+            "body": formatter(instance)
+        }
+
+        # TODO: Implement actual e-mail sending here when avaiable e-mail servers are clarified
+
+        # Return a 202 ACCEPTED with a copy of the email body
+        return Response({"email": email_body}, status=status.HTTP_202_ACCEPTED)
+
+    def internal_share(self, user, type, id):
+        return Response(status=status.HTTP_501_NOT_IMPLEMENTED)
+
+    def get_email_formatter(self, type):
+        formatter = None
+        if type == "position":
+            def formatter(instance):
+                return f"This position has been shared with you via TalentMAP\n\n" \
+                       f"\tPosition Number: {instance.position_number}\n\tPosition Title: {instance.title}\n" \
+                       f"\tPost: {instance.post}"
+        return formatter

--- a/talentmap_api/common/views.py
+++ b/talentmap_api/common/views.py
@@ -44,12 +44,12 @@ class ShareView(APIView):
         a string explanation of the validation error.
         '''
         if "mode" not in request.data:
-            return (False, "POSTs to this endpoint require the mode parameter")
+            return (False, "POSTs to this endpoint require the 'mode' parameter")
         elif request.data.get("mode") not in self.AVAILABLE_MODES:
             return (False, f"Mode must be one of the following: {','.join(self.AVAILABLE_MODES)}")
 
         if "type" not in request.data:
-            return (False, "POSTs to this endpoint require the type parameter")
+            return (False, "POSTs to this endpoint require the 'type' parameter")
         elif request.data.get("type") not in self.AVAILABLE_TYPES.keys():
             return (False, f"Type must be one of the following: {','.join(self.AVAILABLE_TYPES.keys())}")
 

--- a/talentmap_api/urls.py
+++ b/talentmap_api/urls.py
@@ -18,11 +18,14 @@ from django.conf.urls import url, include
 from django.conf.urls.static import static
 from rest_framework_swagger.views import get_swagger_view
 
+from talentmap_api.common.views import ShareView
+
 urlpatterns = [
     url(r'^$', get_swagger_view(title='TalentMAP API')),
     url(r'^api/v1/language/', include('talentmap_api.language.urls')),
     url(r'^api/v1/position/', include('talentmap_api.position.urls')),
     url(r'^api/v1/organization/', include('talentmap_api.organization.urls')),
+    url(r'^api/v1/share/', ShareView.as_view()),
 ] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
 
 if settings.DEBUG:  # pragma: no cover


### PR DESCRIPTION
This response issue #40 

* Created `/api/v1/share/` which accepts a post body to support internal and external sharing of various TalentMAP objects
  * Currently supports sharing `position`
  * Currently supports sharing via `email` - This is "spoofed", in that the response from the server will be `202 ACCEPTED` but does not actually send an e-mail as we are not sure of what sort of email services we will have access to yet
* Added tests for `/api/v1/share/` endpoint and its validator
* Fixed a small bug where TOD descriptions were loaded into the wrong fields

Tagging @jseppi as an additional reviewer in case @burgwyn is too busy with his move. 