### PR TITLE
M2M Filter Fix, Ordering

### DIFF
--- a/talentmap_api/common/filters.py
+++ b/talentmap_api/common/filters.py
@@ -25,7 +25,7 @@ class DisabledHTMLFilterBackend(DjangoFilterBackend):
 
 def negate_boolean_filter(lookup_expr):
     '''
-    Curries a function which xecutes a boolean filter, but negating the incoming value.
+    Curries a function which executes a boolean filter, but negating the incoming value.
     This is needed because in the case of reversing a many to many relationship
     an exclusion is not always equivalent to a negative filter.
 

--- a/talentmap_api/common/filters.py
+++ b/talentmap_api/common/filters.py
@@ -12,6 +12,7 @@ INTEGER_LOOKUPS = ['exact', 'gte', 'gt', 'lte', 'lt', 'range']
 BASIC_TEXT_LOOKUPS = ['exact', 'iexact', 'startswith', 'istartswith',
                       'endswith', 'iendswith']
 ALL_TEXT_LOOKUPS = BASIC_TEXT_LOOKUPS + ['contains', 'icontains', 'in', 'isnull']
+FOREIGN_KEY_LOOKUPS = ['exact', 'in']
 
 
 # This filter backend removes the form rendering which calls the database excessively
@@ -20,6 +21,24 @@ class DisabledHTMLFilterBackend(DjangoFilterBackend):
     # This is not covered by tests as it exists solely on the browsable API
     def to_html(self, request, queryset, view):  # pragma: no cover
         return ""
+
+
+def negate_boolean_filter(lookup_expr):
+    '''
+    Curries a function which xecutes a boolean filter, but negating the incoming value.
+    This is needed because in the case of reversing a many to many relationship
+    an exclusion is not always equivalent to a negative filter.
+
+    For example:
+    TourOfDuty.objects.filter(posts__positions__isnull=False) will return different results from
+    TourOfDuty.objects.exclude(posts__positions__isnull=True)
+    '''
+    def filter_method(queryset, name, value):
+        value = not value
+        lookup = LOOKUP_SEP.join([name, lookup_expr])
+        return queryset.filter(Q(**{lookup: value})).distinct()
+
+    return filter_method
 
 
 def multi_field_filter(fields, lookup_expr='exact', exclude=False):

--- a/talentmap_api/language/filters.py
+++ b/talentmap_api/language/filters.py
@@ -3,14 +3,15 @@ from django.db.models.constants import LOOKUP_SEP
 from django.db.models import Q
 
 from talentmap_api.language.models import Qualification, Proficiency, Language
-from talentmap_api.common.filters import multi_field_filter, ALL_TEXT_LOOKUPS
+from talentmap_api.common.filters import multi_field_filter, negate_boolean_filter
+from talentmap_api.common.filters import ALL_TEXT_LOOKUPS, FOREIGN_KEY_LOOKUPS
 
 
 class LanguageFilter(filters.FilterSet):
     # Convenience filter of "name" which will perform a contains lookup on the description
     name = filters.CharFilter(name="long_description", lookup_expr="contains")
 
-    available = filters.BooleanFilter(name="qualifications__positions", lookup_expr="isnull", exclude=True)
+    available = filters.BooleanFilter(name="qualifications__positions", method=negate_boolean_filter("isnull"))
 
     class Meta:
         model = Language
@@ -66,4 +67,8 @@ class QualificationFilter(filters.FilterSet):
 
     class Meta:
         model = Qualification
-        fields = {}
+        fields = {
+            "language": FOREIGN_KEY_LOOKUPS,
+            "written_proficiency": FOREIGN_KEY_LOOKUPS,
+            "spoken_proficiency": FOREIGN_KEY_LOOKUPS
+        }

--- a/talentmap_api/organization/filters.py
+++ b/talentmap_api/organization/filters.py
@@ -4,7 +4,8 @@ from django.db.models import Q
 from django.db.models.constants import LOOKUP_SEP
 
 from talentmap_api.organization.models import Organization, Post, TourOfDuty
-from talentmap_api.common.filters import multi_field_filter, ALL_TEXT_LOOKUPS, INTEGER_LOOKUPS
+from talentmap_api.common.filters import multi_field_filter, negate_boolean_filter
+from talentmap_api.common.filters import ALL_TEXT_LOOKUPS, INTEGER_LOOKUPS, FOREIGN_KEY_LOOKUPS
 
 
 class OrganizationFilter(filters.FilterSet):
@@ -20,13 +21,15 @@ class OrganizationFilter(filters.FilterSet):
             "code": ALL_TEXT_LOOKUPS,
             "long_description": ALL_TEXT_LOOKUPS,
             "short_description": ALL_TEXT_LOOKUPS,
+            "bureau_organization": FOREIGN_KEY_LOOKUPS,
+            "parent_organization": FOREIGN_KEY_LOOKUPS,
             "is_bureau": ['exact'],
             "is_regional": ['exact']
         }
 
 
 class TourOfDutyFilter(filters.FilterSet):
-    available = filters.BooleanFilter(name="posts__positions", lookup_expr="isnull", exclude=True)
+    available = filters.BooleanFilter(name="posts__positions", method=negate_boolean_filter("isnull"))
 
     class Meta:
         model = TourOfDuty
@@ -52,6 +55,7 @@ class PostFilter(filters.FilterSet):
             "differential_rate": INTEGER_LOOKUPS,
             "danger_pay": INTEGER_LOOKUPS,
             "rest_relaxation_point": ALL_TEXT_LOOKUPS,
+            "tour_of_duty": FOREIGN_KEY_LOOKUPS,
             "has_consumable_allowance": ["exact"],
             "has_service_needs_differential": ["exact"]
         }

--- a/talentmap_api/position/filters.py
+++ b/talentmap_api/position/filters.py
@@ -8,7 +8,7 @@ from talentmap_api.language.models import Qualification
 from talentmap_api.organization.filters import OrganizationFilter, PostFilter
 from talentmap_api.organization.models import Organization, Post
 
-from talentmap_api.common.filters import full_text_search, ALL_TEXT_LOOKUPS, DATE_LOOKUPS
+from talentmap_api.common.filters import full_text_search, ALL_TEXT_LOOKUPS, DATE_LOOKUPS, FOREIGN_KEY_LOOKUPS
 
 
 class GradeFilter(filters.FilterSet):
@@ -58,6 +58,12 @@ class PositionFilter(filters.FilterSet):
             "position_number": ALL_TEXT_LOOKUPS,
             "title": ALL_TEXT_LOOKUPS,
             "is_overseas": ["exact"],
+            "languages": FOREIGN_KEY_LOOKUPS,
+            "grade": FOREIGN_KEY_LOOKUPS,
+            "skill": FOREIGN_KEY_LOOKUPS,
+            "organization": FOREIGN_KEY_LOOKUPS,
+            "bureau": FOREIGN_KEY_LOOKUPS,
+            "post": FOREIGN_KEY_LOOKUPS,
             "create_date": DATE_LOOKUPS,
             "update_date": DATE_LOOKUPS
         }

--- a/talentmap_api/settings.py
+++ b/talentmap_api/settings.py
@@ -95,6 +95,7 @@ TEMPLATES = [
 REST_FRAMEWORK = {
     'DEFAULT_FILTER_BACKENDS': (
         'talentmap_api.common.filters.DisabledHTMLFilterBackend',
+        'rest_framework.filters.OrderingFilter'
     ),
 }
 


### PR DESCRIPTION
This PR fixes a bug @mjoyce91 found, where a filter applied to a reverse many-to-many relationship would not function correctly.

```
>>> TourOfDuty.objects.filter(posts__positions__isnull=False).distinct().values_list("id", flat=True)
<QuerySet [1, 6, 7, 8, 11, 12, 17, 19, 20]>
>>> TourOfDuty.objects.exclude(posts__positions__isnull=True).distinct().values_list("id", flat=True)
<QuerySet [19]> 
```

This output exemplifies the problem. The filters were performing the second logic, when it was expect that they would perform the first. This PR resolves that issue, as well as adds in the ordering backend to support response ordering.

Additionally, it was not possible to use `__in` on a foreign key relationship, because they were not explicitly permitted. This PR resolves this issue as well.

Tagging @jseppi and @burgwyn since Nat may be busy with his move.