### PR TITLE
Ordering Fixes

### DIFF
--- a/talentmap_api/common/tests/test_ordering.py
+++ b/talentmap_api/common/tests/test_ordering.py
@@ -1,0 +1,47 @@
+import pytest
+import json
+
+from django.contrib.auth.models import User
+
+from model_mommy import mommy
+from model_mommy.recipe import Recipe
+from rest_framework import status
+
+
+@pytest.fixture
+def test_ordering_position_fixture():
+    post_1 = mommy.make('organization.Post', id=1, has_service_needs_differential=True)
+    post_2 = mommy.make('organization.Post', id=2, has_service_needs_differential=False)
+
+    position_1 = mommy.make('position.Position', id=1, post=post_1, position_number="1234")
+    position_2 = mommy.make('position.Position', id=2, post=post_2, position_number="5678")
+
+
+@pytest.mark.django_db()
+@pytest.mark.usefixtures("test_ordering_position_fixture")
+def test_regular_ordering(client):
+    response = client.get('/api/v1/position/?ordering=position_number')
+    assert response.status_code == status.HTTP_200_OK
+
+    assert response.data[0]["position_number"] == "1234"
+
+    response = client.get('/api/v1/position/?ordering=-position_number')
+
+    assert response.status_code == status.HTTP_200_OK
+
+    assert response.data[0]["position_number"] == "5678"
+
+
+@pytest.mark.django_db()
+@pytest.mark.usefixtures("test_ordering_position_fixture")
+def test_nested_ordering(client):
+    response = client.get('/api/v1/position/?ordering=post__has_service_needs_differential')
+    assert response.status_code == status.HTTP_200_OK
+
+    assert response.data[0]["position_number"] == "5678"
+
+    response = client.get('/api/v1/position/?ordering=-post__has_service_needs_differential')
+
+    assert response.status_code == status.HTTP_200_OK
+
+    assert response.data[0]["position_number"] == "1234"

--- a/talentmap_api/settings.py
+++ b/talentmap_api/settings.py
@@ -106,7 +106,7 @@ TEMPLATES = [
 REST_FRAMEWORK = {
     'DEFAULT_FILTER_BACKENDS': (
         'talentmap_api.common.filters.DisabledHTMLFilterBackend',
-        'rest_framework.filters.OrderingFilter'
+        'talentmap_api.common.filters.RelatedOrderingFilter'
     ),
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'rest_framework_expiring_authtoken.authentication.ExpiringTokenAuthentication',


### PR DESCRIPTION
This PR adds tests and fixes for a bug with the DRF ordering functionality, wherein ordering on a nested field would not produce any effect.

i.e. `/api/v1/postion/?ordering=skill__description` would not order on the skill description as you would expect. Now it does.

Tagging @mjoyce91 for visibility