### PR TITLE
Switch to sharing inference

### DIFF
--- a/talentmap_api/common/tests/test_sharing.py
+++ b/talentmap_api/common/tests/test_sharing.py
@@ -29,20 +29,17 @@ def test_sharing_update_fixture(authorized_user):
 @pytest.mark.django_db()
 @pytest.mark.parametrize("payload, resp", [
     ({}, status.HTTP_400_BAD_REQUEST),
-    ({"mode": "banana"}, status.HTTP_400_BAD_REQUEST),
-    ({"mode": "email"}, status.HTTP_400_BAD_REQUEST),
-    ({"mode": "email", "email": "a@a.c"}, status.HTTP_400_BAD_REQUEST),
-    ({"mode": "email", "type": "position"}, status.HTTP_400_BAD_REQUEST),
-    ({"mode": "email", "type": "position", "id": 1}, status.HTTP_400_BAD_REQUEST),
-    ({"mode": "email", "email": "a@a.c", "type": "banana"}, status.HTTP_400_BAD_REQUEST),
-    ({"mode": "email", "email": "a@a.c", "type": "position", "id": 1}, status.HTTP_404_NOT_FOUND),
-    ({"mode": "email", "email": "a@a.c", "type": "position", "id": 2}, status.HTTP_202_ACCEPTED),
-    ({"mode": "internal"}, status.HTTP_400_BAD_REQUEST),
-    ({"mode": "internal", "email": "a@a.c"}, status.HTTP_400_BAD_REQUEST),
-    ({"mode": "internal", "id": 1, "type": "position"}, status.HTTP_400_BAD_REQUEST),
-    ({"mode": "internal", "email": "test@state.gov", "type": "position", "id": 1}, status.HTTP_404_NOT_FOUND),
-    ({"mode": "internal", "email": "dne@state.gov", "type": "position", "id": 2}, status.HTTP_404_NOT_FOUND),
-    ({"mode": "internal", "email": "test@state.gov", "type": "position", "id": 2}, status.HTTP_202_ACCEPTED),
+    ({"email": "a@a.c"}, status.HTTP_400_BAD_REQUEST),
+    ({"type": "position"}, status.HTTP_400_BAD_REQUEST),
+    ({"type": "position", "id": 1}, status.HTTP_400_BAD_REQUEST),
+    ({"email": "a@a.c", "type": "banana"}, status.HTTP_400_BAD_REQUEST),
+    ({"email": "a@a.c", "type": "position", "id": 1}, status.HTTP_404_NOT_FOUND),
+    ({"email": "a@a.c", "type": "position", "id": 2}, status.HTTP_202_ACCEPTED),
+    ({"email": "a@a.c"}, status.HTTP_400_BAD_REQUEST),
+    ({"id": 1, "type": "position"}, status.HTTP_400_BAD_REQUEST),
+    ({"email": "test@state.gov", "type": "position", "id": 1}, status.HTTP_404_NOT_FOUND),
+    ({"email": "dne@state.gov", "type": "position", "id": 2}, status.HTTP_404_NOT_FOUND),
+    ({"email": "test@state.gov", "type": "position", "id": 2}, status.HTTP_202_ACCEPTED),
 ])
 @pytest.mark.usefixtures("test_sharing_fixture")
 def test_payload_validation(authorized_client, authorized_user, payload, resp):

--- a/talentmap_api/user_profile/views.py
+++ b/talentmap_api/user_profile/views.py
@@ -89,7 +89,6 @@ class ShareView(GenericViewSet,
 
     Post method accepts an object with at minimum the following parameters:
     * type - the type of object to be shared (position)
-    * mode - the mode of sharing (internal, email)
     * id - the id of the object to be shared
     * email - the email to send the share to
 


### PR DESCRIPTION
This PR handles issue #74 

* Switch sharing to infer internal/external by e-mail
* When sharing, if destination user has `state.gov` email address, share internally. Otherwise, share externally

@mjoyce91 this removes the need for `mode` in the request object