### PR TITLE
CSV Downloads, Field Limiting

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ django-extensions==1.7.9
 django-filter==1.0.4
 django-rest-swagger==2.1.2
 djangorestframework==3.6.3
+djangorestframework-csv==2.0.0
 djangorestframework-expiring-authtoken==0.1.4
 djangorestframework-filters==0.10.1
 gitdb2==2.0.2
@@ -38,5 +39,6 @@ six==1.10.0
 smmap2==2.0.3
 sqlparse==0.2.3
 stevedore==1.23.0
+unicodecsv==0.14.1
 uritemplate==3.0.0
 urllib3==1.21.1

--- a/talentmap_api/common/renderers.py
+++ b/talentmap_api/common/renderers.py
@@ -1,0 +1,37 @@
+'''
+Modified from https://github.com/mjumbewu/django-rest-framework-csv
+Supports CSV rendering on paginated views
+'''
+
+from rest_framework_csv.renderers import CSVRenderer
+
+
+class PaginatedCSVRenderer (CSVRenderer):
+    results_field = 'results'
+
+    def render(self, data, *args, **kwargs):
+        '''
+        We need the handle the following cases:
+            1. Paginated endpoint
+                 {
+                    page_metadata
+                    results: [<RENDERABLES>]
+                 }
+            2. Non-paginated list endpoints
+                [<RENDERABLES>]
+            3. Single-object retrieve endpoints
+                <RENDERABLE>
+        '''
+
+        '''
+        In case 2, we don't need to do anything
+        In cases 1 & 3, the data is not a list, so we check for that here
+        '''
+        if not isinstance(data, list):
+            '''
+            In case 1, we have a data[results_field] array, so that is returned
+            In case 3, we don't, so we hit the default of creating an array with
+            a single item, the retrieved object
+            '''
+            data = data.get(self.results_field, [data])
+        return super(PaginatedCSVRenderer, self).render(data, *args, **kwargs)

--- a/talentmap_api/settings.py
+++ b/talentmap_api/settings.py
@@ -105,6 +105,11 @@ TEMPLATES = [
 # Rest framework settings
 REST_FRAMEWORK = {
     'DEFAULT_PAGINATION_CLASS': 'talentmap_api.common.pagination.ControllablePageNumberPagination',
+    'DEFAULT_RENDERER_CLASSES': (
+        'rest_framework.renderers.JSONRenderer',
+        'rest_framework.renderers.BrowsableAPIRenderer',
+        'talentmap_api.common.renderers.PaginatedCSVRenderer',
+    ),
     'DEFAULT_FILTER_BACKENDS': (
         'talentmap_api.common.filters.DisabledHTMLFilterBackend',
         'talentmap_api.common.filters.RelatedOrderingFilter'


### PR DESCRIPTION
This PR handles #79 

Quick list:
* Adds `?format` option to all endpoints, supporting `json` `csv` and `api` (HTML browsable API)
* Adds `?include` and `?exclude` options to all endpoints, supporting dynamic field selection

Details:
This PR adds the venerable `?format=csv` option to all endpoints. It will render whatever data would have been returned with `?format=json`, but as a flattened CSV instead. It respects all filters, ordering, and pagination options in the query parameters. (i.e. `?limit=10` will return only 10 items, etc.) Examples:

`/api/v1/positions/?q=german&format=csv` - download all positions on the first page of the search matching FTS for 'german'

`/api/v1/positions/?limit=1000&grade__code=05` - download the first 1000 positions whose grade code is 05

Additionally, this PR adds the `?include` and `?exclude` query parameters (and tests for these new parameters). These override the default field inclusion and exclusion lists, allowing users to dynamically change which fields are returned in their dataset. This functionality is _very_ nice when you only want to download a subset of data in your CSV. Examples:

`/api/v1/positions/?include=description__id,languages&limit=10` - would return only the description id's and language data for the first 10 positions.

`/api/v1/positions/?exclude=languages` - would return all position data, with the exception of languages

You can combine them as well, like:
`/api/v1/positions/?include=post,representation&exclude=post__tour_of_duty` - would return only the post data and representations for positions, excluding tours of duty on the post data

@mjoyce91 tagging for visibility