### PR TITLE
Favorite action endpoint

### DIFF
--- a/talentmap_api/position/tests/test_position_endpoints.py
+++ b/talentmap_api/position/tests/test_position_endpoints.py
@@ -164,3 +164,27 @@ def test_domestic_filtering(client):
     response_2 = client.get('/api/v1/position/?is_overseas=true')
 
     assert response_1.data == response_2.data
+
+
+@pytest.mark.django_db()
+def test_favorite_action_endpoints(authorized_client, authorized_user):
+    position = mommy.make('position.Position')
+    response = authorized_client.get(f'/api/v1/position/{position.id}/favorite/')
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    response = authorized_client.put(f'/api/v1/position/{position.id}/favorite/')
+
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+
+    response = authorized_client.get(f'/api/v1/position/{position.id}/favorite/')
+
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+
+    response = authorized_client.delete(f'/api/v1/position/{position.id}/favorite/')
+
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+
+    response = authorized_client.get(f'/api/v1/position/{position.id}/favorite/')
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND

--- a/talentmap_api/position/urls/position.py
+++ b/talentmap_api/position/urls/position.py
@@ -9,6 +9,7 @@ router.register(r'', views.PositionListView, base_name="position.Position")
 
 urlpatterns = [
     url(r'^favorites/$', views.PositionFavoriteListView.as_view(get_list), name='view-favorite-positions'),
+    url(r'^(?P<pk>[0-9]+)/favorite/$', views.PositionFavoriteActionView.as_view(), name='position.Position-favorite'),
 ]
 
 urlpatterns += router.urls


### PR DESCRIPTION
This PR handles #112 

Follows how github handles starring gists: https://developer.github.com/v3/gists/#star-a-gist

Adds:
- GET `/api/v1/position/{pk}/favorite/` - Returns 204 if the position is the logged in user's favorite, or 404 otherwise
- PUT `/api/v1/position/{pk}/favorite/` - Returns 204, adds the position as the logged in user's favorite 
- DELETE `/api/v1/position/{pk}/favorite/` - Returns 204, removes the position from the logged in user's favorites

@mjoyce91 you can still do a mass-update by PATCHing the user profile favorites list with an array of ids