### PR TITLE
Default read only serializers

### DIFF
--- a/talentmap_api/language/serializers.py
+++ b/talentmap_api/language/serializers.py
@@ -38,3 +38,4 @@ class LanguageQualificationWritableSerializer(PrefetchedSerializer):
     class Meta:
         model = Qualification
         fields = "__all__"
+        writable_fields = ("language", "reading_proficiency", "spoken_proficiency")

--- a/talentmap_api/messaging/serializers.py
+++ b/talentmap_api/messaging/serializers.py
@@ -10,4 +10,4 @@ class NotificationSerializer(PrefetchedSerializer):
     class Meta:
         model = Notification
         fields = "__all__"
-        read_only_fields = ("owner", "date_created", "date_updated", "message")
+        writable_fields = ("is_read")

--- a/talentmap_api/position/serializers.py
+++ b/talentmap_api/position/serializers.py
@@ -16,6 +16,7 @@ class CapsuleDescriptionSerializer(PrefetchedSerializer):
     class Meta:
         model = CapsuleDescription
         fields = "__all__"
+        writable_fields = ("content",)
 
 
 class PositionSerializer(PrefetchedSerializer):

--- a/talentmap_api/user_profile/serializers.py
+++ b/talentmap_api/user_profile/serializers.py
@@ -36,6 +36,7 @@ class SharableSerializer(PrefetchedSerializer):
     class Meta:
         model = Sharable
         fields = ["id", "sharing_user", "receiving_user", "content", "is_read"]
+        writable_fields = ("is_read",)
 
 
 class UserProfileSerializer(PrefetchedSerializer):
@@ -87,6 +88,7 @@ class UserProfileWritableSerializer(PrefetchedSerializer):
     class Meta:
         model = UserProfile
         fields = ["language_qualifications", "favorite_positions"]
+        writable_fields = ("language_qualifications", "favorite_positions",)
 
 
 class SavedSearchSerializer(PrefetchedSerializer):
@@ -125,4 +127,4 @@ class SavedSearchSerializer(PrefetchedSerializer):
     class Meta:
         model = SavedSearch
         fields = "__all__"
-        read_only_fields = ("count",)
+        writable_fields = ("name", "endpoint", "filters",)


### PR DESCRIPTION
This PR addresses #107 

Adding @jseppi as a reviewer since this was his issue

- Added functionality to `PrefetchedSerializer` (which all serializers we use inherit from) to set all fields to be `read_only` _unless_ they are present in a `writable_fields` option in the descendant serializer's `Meta` class. This replicates the functionality of DRF native `read_only_fields` in the inverse, and doesn't step on the functionality of other DRF `Meta` based code
- Updated all relevant serializers to specify `writable_fields`