### PR TITLE
Fixing PR requests, also adding extra validation and tests

### DIFF
--- a/talentmap_api/common/tests/test_sharing.py
+++ b/talentmap_api/common/tests/test_sharing.py
@@ -73,6 +73,18 @@ def test_update_internal_share(authorized_client, authorized_user):
     share = authorized_user.profile.received_shares.first()
     assert not share.is_read
 
+    # Attempt to patch a non-existant share
+    response = authorized_client.patch(f"/api/v1/share/1234/", data=json.dumps({
+        "is_read": True
+    }), content_type="application/json")
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    # Attempt to patch a invalid fields
+    response = authorized_client.patch(f"/api/v1/share/1/", data=json.dumps({
+        "sharable_id": 2
+    }), content_type="application/json")
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
     response = authorized_client.patch(f"/api/v1/share/1/", data=json.dumps({
         "is_read": True
     }), content_type="application/json")
@@ -82,4 +94,5 @@ def test_update_internal_share(authorized_client, authorized_user):
     assert share.is_read
 
     response = authorized_client.get(f"/api/v1/profile/", content_type="application/json")
+    assert response.status_code == status.HTTP_200_OK
     assert len(response.data["received_shares"]) == 1

--- a/talentmap_api/common/tests/test_sharing.py
+++ b/talentmap_api/common/tests/test_sharing.py
@@ -79,7 +79,7 @@ def test_update_internal_share(authorized_client, authorized_user):
     }), content_type="application/json")
     assert response.status_code == status.HTTP_404_NOT_FOUND
 
-    # Attempt to patch a invalid fields
+    # Attempt to patch invalid fields
     response = authorized_client.patch(f"/api/v1/share/1/", data=json.dumps({
         "sharable_id": 2
     }), content_type="application/json")

--- a/talentmap_api/messaging/views.py
+++ b/talentmap_api/messaging/views.py
@@ -1,4 +1,5 @@
 from django.core.exceptions import ObjectDoesNotExist
+from django.shortcuts import get_object_or_404
 from django.apps import apps
 
 from rest_framework.viewsets import GenericViewSet
@@ -61,16 +62,13 @@ class ShareView(FieldLimitableSerializerMixin,
 
         This method is mainly used to update the read status of a share
         '''
-        share = Sharable.objects.filter(receiving_user=self.request.user.profile, id=pk).first()
-        if not share:
-            return Response(status=status.HTTP_404_NOT_FOUND)
-
+        share = get_object_or_404(Sharable, receiving_user=self.request.user.profile, id=pk)
         serializer = self.serializer_class(share, data=request.data, partial=True)
         if serializer.is_valid():
             serializer.save()
             return Response(status=status.HTTP_204_NO_CONTENT)
-
-        return Response(status=status.HTTP_400_BAD_REQUEST)
+        else:
+            return Response(status=status.HTTP_400_BAD_REQUEST)
 
     def post(self, request, format=None):
         '''

--- a/talentmap_api/position/views.py
+++ b/talentmap_api/position/views.py
@@ -117,7 +117,7 @@ class PositionHighlightActionView(APIView):
         '''
         Indicates if the position is highlighted
 
-        Returns 204 if the position is a favorite, otherwise, 404
+        Returns 204 if the position is highlighted, otherwise, 404
         '''
         if Position.objects.get(id=pk).highlighted_by_org.count() > 0:
             return Response(status=status.HTTP_204_NO_CONTENT)
@@ -134,7 +134,7 @@ class PositionHighlightActionView(APIView):
 
     def delete(self, request, pk, format=None):
         '''
-        Removes the position from favorites
+        Removes the position from highlighted positions
         '''
         position = Position.objects.get(id=pk)
         position.bureau.highlighted_positions.remove(position)


### PR DESCRIPTION
@jseppi This addresses your comments on the Sprint 7 PR

Additionally
- Adds a few extra tests for sharing
- Updates the common serializer to perform Validation to ensure that no invalid data is being written, and to properly send back a 400 error in the case that a partial update object is empty after stripping out invalid data.