### PR TITLE
Add bid cycle batch endpoint

### DIFF
--- a/talentmap_api/bidding/urls/bidcycle.py
+++ b/talentmap_api/bidding/urls/bidcycle.py
@@ -7,5 +7,6 @@ urlpatterns = [
     url(r'^$', views.BidCycleView.as_view({**get_list, **post_create})),
     url(r'^(?P<pk>[0-9]+)/$', views.BidCycleView.as_view({**get_retrieve, **patch_update}), name="bidding.BidCycle-details"),
     url(r'^(?P<pk>[0-9]+)/position/(?P<pos_id>[0-9]+)/$', views.BidCyclePositionActionView.as_view(), name='bidding.BidCycle-position-actions'),
-    url(r'^(?P<pk>[0-9]+)/positions/$', views.BidCycleListPositionView.as_view(get_list), name="bidding.BidCycle-list-positions")
+    url(r'^(?P<pk>[0-9]+)/positions/$', views.BidCycleListPositionView.as_view(get_list), name="bidding.BidCycle-list-positions"),
+    url(r'^(?P<pk>[0-9]+)/position/batch/(?P<saved_search_id>[0-9]+)/$', views.BidCycleBatchPositionActionView.as_view(), name="bidding.BidCycle-position-batch")
 ]

--- a/talentmap_api/user_profile/models.py
+++ b/talentmap_api/user_profile/models.py
@@ -57,8 +57,11 @@ class SavedSearch(models.Model):
     date_created = models.DateTimeField(auto_now_add=True)
     date_updated = models.DateTimeField(auto_now=True)
 
+    def get_queryset(self):
+        return get_filtered_queryset(resolve_path_to_view(self.endpoint).filter_class, self.filters)
+
     def update_count(self):
-        count = get_filtered_queryset(resolve_path_to_view(self.endpoint).filter_class, self.filters).count()
+        count = self.get_queryset().count()
         if self.count != count:
             # Create a notification for this saved search's owner if the amount has increased
             diff = count - self.count


### PR DESCRIPTION
- Adds PUT `/api/v1/bidcycle/{id}/position/batch/{saved_search_id}` which adds all positions from the saved search to the bid cycle
- This is actually like super cool cause it covers all of the examples Robin showed me last sprint planning + is extensible because you can use any filter to create your batches.