### PR TITLE
Add calculated fairshare to bidcycle survey

### DIFF
--- a/talentmap_api/bidding/serializers.py
+++ b/talentmap_api/bidding/serializers.py
@@ -42,6 +42,13 @@ class BidCycleSerializer(PrefetchedSerializer):
 
 
 class SurveySerializer(PrefetchedSerializer):
+    calculated_values = serializers.SerializerMethodField()
+
+    def get_calculated_values(self, obj):
+        calculated_values = {}
+        calculated_values['is_fairshare'] = obj.user.is_fairshare
+
+        return calculated_values
 
     class Meta:
         model = StatusSurvey


### PR DESCRIPTION
Realized we weren't outwardly displaying the calculated fairshare anywhere. For now I've added it to the status survey, so a CDO can see the self-identified fairshare status and the system calculated fairshare status. 

We'll probably merge this into staging during the next sprint.