### PR TITLE
Allow extra filters on FK assignments

### DIFF
--- a/talentmap_api/bidding/filters.py
+++ b/talentmap_api/bidding/filters.py
@@ -1,7 +1,7 @@
 import rest_framework_filters as filters
 
 from talentmap_api.bidding.models import BidCycle, Bid, StatusSurvey, UserBidStatistics
-from talentmap_api.common.filters import ALL_TEXT_LOOKUPS, DATE_LOOKUPS, INTEGER_LOOKUPS
+from talentmap_api.common.filters import ALL_TEXT_LOOKUPS, DATE_LOOKUPS, INTEGER_LOOKUPS, FOREIGN_KEY_LOOKUPS
 
 
 class BidCycleFilter(filters.FilterSet):
@@ -39,6 +39,7 @@ class UserBidStatisticsFilter(filters.FilterSet):
             "approved": INTEGER_LOOKUPS,
             "declined": INTEGER_LOOKUPS,
             "closed": INTEGER_LOOKUPS,
+            "bidcycle": FOREIGN_KEY_LOOKUPS
         }
 
 
@@ -50,5 +51,6 @@ class StatusSurveyFilter(filters.FilterSet):
         fields = {
             "is_differential_bidder": ["exact"],
             "is_fairshare": ["exact"],
-            "is_six_eight": ["exact"]
+            "is_six_eight": ["exact"],
+            "bidcycle": FOREIGN_KEY_LOOKUPS
         }

--- a/talentmap_api/language/filters.py
+++ b/talentmap_api/language/filters.py
@@ -9,7 +9,7 @@ from talentmap_api.bidding.filters import BidCycleFilter
 
 from talentmap_api.language.models import Qualification, Proficiency, Language, Waiver
 from talentmap_api.common.filters import multi_field_filter, negate_boolean_filter
-from talentmap_api.common.filters import ALL_TEXT_LOOKUPS, DATE_LOOKUPS
+from talentmap_api.common.filters import ALL_TEXT_LOOKUPS, DATE_LOOKUPS, FOREIGN_KEY_LOOKUPS
 
 
 class LanguageFilter(filters.FilterSet):
@@ -72,7 +72,11 @@ class QualificationFilter(filters.FilterSet):
 
     class Meta:
         model = Qualification
-        fields = {}
+        fields = {
+            "language": FOREIGN_KEY_LOOKUPS,
+            "reading_proficiency": FOREIGN_KEY_LOOKUPS,
+            "spoken_proficiency": FOREIGN_KEY_LOOKUPS
+        }
 
 
 class WaiverFilter(filters.FilterSet):
@@ -86,5 +90,8 @@ class WaiverFilter(filters.FilterSet):
             "type": ALL_TEXT_LOOKUPS,
             "status": ALL_TEXT_LOOKUPS,
             "request_date": DATE_LOOKUPS,
-            "decision_date": DATE_LOOKUPS
+            "decision_date": DATE_LOOKUPS,
+            "language": FOREIGN_KEY_LOOKUPS,
+            "bidcycle": FOREIGN_KEY_LOOKUPS,
+            "position": FOREIGN_KEY_LOOKUPS
         }

--- a/talentmap_api/messaging/filters.py
+++ b/talentmap_api/messaging/filters.py
@@ -5,7 +5,7 @@ from talentmap_api.messaging.models import Notification
 from talentmap_api.user_profile.models import UserProfile
 from talentmap_api.user_profile.filters import UserProfileFilter
 
-from talentmap_api.common.filters import array_field_filter, ALL_TEXT_LOOKUPS, DATE_LOOKUPS
+from talentmap_api.common.filters import array_field_filter, ALL_TEXT_LOOKUPS, DATE_LOOKUPS, FOREIGN_KEY_LOOKUPS
 
 
 class NotificationFilter(filters.FilterSet):
@@ -20,5 +20,6 @@ class NotificationFilter(filters.FilterSet):
             "message": ALL_TEXT_LOOKUPS,
             "is_read": ['exact'],
             "date_created": DATE_LOOKUPS,
-            "date_updated": DATE_LOOKUPS
+            "date_updated": DATE_LOOKUPS,
+            "owner": FOREIGN_KEY_LOOKUPS
         }

--- a/talentmap_api/organization/filters.py
+++ b/talentmap_api/organization/filters.py
@@ -2,7 +2,7 @@ import rest_framework_filters as filters
 
 from talentmap_api.organization.models import Organization, Post, TourOfDuty, Location, Country
 from talentmap_api.common.filters import multi_field_filter, negate_boolean_filter, full_text_search
-from talentmap_api.common.filters import ALL_TEXT_LOOKUPS, INTEGER_LOOKUPS
+from talentmap_api.common.filters import ALL_TEXT_LOOKUPS, INTEGER_LOOKUPS, FOREIGN_KEY_LOOKUPS
 
 
 class OrganizationFilter(filters.FilterSet):
@@ -20,7 +20,10 @@ class OrganizationFilter(filters.FilterSet):
             "long_description": ALL_TEXT_LOOKUPS,
             "short_description": ALL_TEXT_LOOKUPS,
             "is_bureau": ['exact'],
-            "is_regional": ['exact']
+            "is_regional": ['exact'],
+            "bureau_organization": FOREIGN_KEY_LOOKUPS,
+            "parent_organization": FOREIGN_KEY_LOOKUPS,
+            "location": FOREIGN_KEY_LOOKUPS
         }
 
 
@@ -70,6 +73,7 @@ class LocationFilter(filters.FilterSet):
             "code": ALL_TEXT_LOOKUPS,
             "city": ALL_TEXT_LOOKUPS,
             "state": ALL_TEXT_LOOKUPS,
+            "country": FOREIGN_KEY_LOOKUPS
         }
 
 
@@ -99,5 +103,7 @@ class PostFilter(filters.FilterSet):
             "danger_pay": INTEGER_LOOKUPS,
             "rest_relaxation_point": ALL_TEXT_LOOKUPS,
             "has_consumable_allowance": ["exact"],
-            "has_service_needs_differential": ["exact"]
+            "has_service_needs_differential": ["exact"],
+            "tour_of_duty": FOREIGN_KEY_LOOKUPS,
+            "location": FOREIGN_KEY_LOOKUPS
         }

--- a/talentmap_api/permission/filters.py
+++ b/talentmap_api/permission/filters.py
@@ -3,7 +3,7 @@ import rest_framework_filters as filters
 from django.contrib.auth.models import Group, Permission
 
 from talentmap_api.common.filters import full_text_search
-from talentmap_api.common.filters import ALL_TEXT_LOOKUPS
+from talentmap_api.common.filters import ALL_TEXT_LOOKUPS, FOREIGN_KEY_LOOKUPS
 
 
 class PermissionFilter(filters.FilterSet):
@@ -38,4 +38,5 @@ class GroupFilter(filters.FilterSet):
         model = Group
         fields = {
             "name": ALL_TEXT_LOOKUPS,
+            "permissions": FOREIGN_KEY_LOOKUPS
         }

--- a/talentmap_api/position/filters.py
+++ b/talentmap_api/position/filters.py
@@ -14,7 +14,7 @@ from talentmap_api.language.models import Qualification
 from talentmap_api.organization.filters import OrganizationFilter, PostFilter, TourOfDutyFilter
 from talentmap_api.organization.models import Organization, Post, TourOfDuty
 
-from talentmap_api.common.filters import full_text_search, ALL_TEXT_LOOKUPS, DATE_LOOKUPS
+from talentmap_api.common.filters import full_text_search, ALL_TEXT_LOOKUPS, DATE_LOOKUPS, FOREIGN_KEY_LOOKUPS
 
 
 class GradeFilter(filters.FilterSet):
@@ -114,7 +114,15 @@ class PositionFilter(filters.FilterSet):
             "title": ALL_TEXT_LOOKUPS,
             "is_overseas": ["exact"],
             "create_date": DATE_LOOKUPS,
-            "update_date": DATE_LOOKUPS
+            "update_date": DATE_LOOKUPS,
+            "post": FOREIGN_KEY_LOOKUPS,
+            "organization": FOREIGN_KEY_LOOKUPS,
+            "bureau": FOREIGN_KEY_LOOKUPS,
+            "skill": FOREIGN_KEY_LOOKUPS,
+            "grade": FOREIGN_KEY_LOOKUPS,
+            "description": FOREIGN_KEY_LOOKUPS,
+            "languages": FOREIGN_KEY_LOOKUPS,
+            "current_assignment": FOREIGN_KEY_LOOKUPS
         }
 
 
@@ -132,4 +140,6 @@ class AssignmentFilter(filters.FilterSet):
             "estimated_end_date": DATE_LOOKUPS,
             "end_date": DATE_LOOKUPS,
             "update_date": DATE_LOOKUPS,
+            "position": FOREIGN_KEY_LOOKUPS,
+            "tour_of_duty": FOREIGN_KEY_LOOKUPS
         }

--- a/talentmap_api/user_profile/filters.py
+++ b/talentmap_api/user_profile/filters.py
@@ -15,7 +15,7 @@ from talentmap_api.user_profile.models import UserProfile
 from talentmap_api.organization.filters import CountryFilter
 from talentmap_api.organization.models import Country
 
-from talentmap_api.common.filters import full_text_search, ALL_TEXT_LOOKUPS, DATE_LOOKUPS
+from talentmap_api.common.filters import full_text_search, ALL_TEXT_LOOKUPS, DATE_LOOKUPS, FOREIGN_KEY_LOOKUPS
 
 
 class UserFilter(filters.FilterSet):
@@ -43,6 +43,13 @@ class UserProfileFilter(filters.FilterSet):
         fields = {
             "date_of_birth": DATE_LOOKUPS,
             "phone_number": ALL_TEXT_LOOKUPS,
+            "user": FOREIGN_KEY_LOOKUPS,
+            "cdo": FOREIGN_KEY_LOOKUPS,
+            "grade": FOREIGN_KEY_LOOKUPS,
+            "skill_code": FOREIGN_KEY_LOOKUPS,
+            "language_qualifications": FOREIGN_KEY_LOOKUPS,
+            "primary_nationality": FOREIGN_KEY_LOOKUPS,
+            "secondary_nationality": FOREIGN_KEY_LOOKUPS
         }
 
 


### PR DESCRIPTION
I removed this a while back because I thought it was causing a bug, but it turns out I was being a bit overzealous. Re-adding FK lookups to the filters.

Right now you can only do something like `/location/?post={id}` but this expands it to allow things like `/location/?post__in={id},{id},{id}` which the front-end needs.

Hopefully we can get this in before #252 :) @jseppi 

@mjoyce91 :eyes: