### PR TITLE
Bug fixes

### DIFF
--- a/talentmap_api/bidding/models.py
+++ b/talentmap_api/bidding/models.py
@@ -212,20 +212,12 @@ def bid_status_changed(sender, instance, **kwargs):
 
 
 @receiver(post_save, sender=Bid, dispatch_uid="save_update_bid_statistics")
-def save_update_bid_statistics(sender, instance, **kwargs):
-    # Get the position associated with this bid and update the statistics
-    instance.position.bid_statistics.get(bidcycle=instance.bidcycle).update_statistics()
-
-    # Update the user's bid statistics
-    statistics, created = UserBidStatistics.objects.get_or_create(user=instance.user, bidcycle=instance.bidcycle)
-    statistics.update_statistics()
-
-
 @receiver(post_delete, sender=Bid, dispatch_uid="delete_update_bid_statistics")
 def delete_update_bid_statistics(sender, instance, **kwargs):
     # Get the position associated with this bid and update the statistics
-    instance.position.bid_statistics.get(bidcycle=instance.bidcycle).update_statistics()
+    statistics, _ = talentmap_api.position.models.PositionBidStatistics.objects.get_or_create(bidcycle=instance.bidcycle, position=instance.position)
+    statistics.update_statistics()
 
     # Update the user's bid statistics
-    statistics, created = UserBidStatistics.objects.get_or_create(user=instance.user, bidcycle=instance.bidcycle)
+    statistics, _ = UserBidStatistics.objects.get_or_create(user=instance.user, bidcycle=instance.bidcycle)
     statistics.update_statistics()

--- a/talentmap_api/bidding/tests/test_bidcycle.py
+++ b/talentmap_api/bidding/tests/test_bidcycle.py
@@ -6,6 +6,7 @@ from model_mommy import mommy
 from rest_framework import status
 
 from talentmap_api.bidding.models import BidCycle, Bid
+from talentmap_api.position.models import PositionBidStatistics
 from talentmap_api.user_profile.models import SavedSearch
 
 
@@ -206,6 +207,8 @@ def test_bidcycle_batch_actions(authorized_client, authorized_user):
     savedsearch.refresh_from_db()
 
     assert len(response.data["results"]) == savedsearch.count
+    # Ensure we've created statistics objects for all of the positions
+    assert PositionBidStatistics.objects.filter(bidcycle_id=2).count() == savedsearch.count
 
 
 @pytest.mark.django_db(transaction=True)

--- a/talentmap_api/common/filters.py
+++ b/talentmap_api/common/filters.py
@@ -135,7 +135,7 @@ def full_text_search(fields):
         # We don't use .distinct() here because it is not respected if filtered afterwards, and, distinct will
         # sort the queryset which is un-needed at this stage of filtering.
 
-        # User queryset.all() to acquire a duplicate of the queryset
+        # Use queryset.all() to acquire a duplicate of the queryset
         id_list = queryset.all().annotate(search=final_vector).filter(q_obj).values_list('id', flat=True)
         return queryset.filter(id__in=id_list)
     return filter_method


### PR DESCRIPTION
@mjoyce91 pointed out a few bugs yesterday

- In some instances, `PositionBidStatistics` isn't created, resulting in a 404 when a bid is made. This is now fixed
- Occasionally when using FTS duplicates would appear in the result set. This was due to using `.distinct()`, which, when used before another `.filter()` (as in this case) would not behave as expected. Altered how the FTS was performed to fix this issue. 