### PR TITLE
Swap description ordering for organizations

### DIFF
--- a/talentmap_api/organization/models.py
+++ b/talentmap_api/organization/models.py
@@ -109,7 +109,7 @@ class Organization(StaticRepresentationModel):
         group.permissions.add(permission)
 
     def __str__(self):
-        return f"{self.long_description} ({self.short_description})"
+        return f"({self.short_description}) {self.long_description}"
 
     class Meta:
         managed = True

--- a/talentmap_api/organization/tests/test_organization_endpoints.py
+++ b/talentmap_api/organization/tests/test_organization_endpoints.py
@@ -35,9 +35,9 @@ def test_organization_list_clear_parent_names(client):
     assert response.status_code == status.HTTP_200_OK
 
     for item in response.data["results"]:
-        assert (item["bureau_organization"] == "Bureau of Cheese Imports ()" or
+        assert (item["bureau_organization"] == "() Bureau of Cheese Imports" or
                 item["bureau_organization"] == "cheese" or
-                item["parent_organization"] == "Bureau of Cheese Imports ()" or
+                item["parent_organization"] == "() Bureau of Cheese Imports" or
                 item["parent_organization"] == "cheese")
 
 

--- a/talentmap_api/user_profile/tests/mommy_recipes.py
+++ b/talentmap_api/user_profile/tests/mommy_recipes.py
@@ -11,6 +11,7 @@ def owned_saved_search():
 def client_for_profile():
     user = mommy.make('auth.User')
     user.profile.cdo = UserProfile.objects.get(user__username="authorized_user")
+    user.profile.date_of_birth = "1975-01-01"
     user.profile.save()
 
     return user.profile


### PR DESCRIPTION
Per ticket, swapped the organization abbreviation and the organization name

`Western Hemispheric Affairs (WHA)` -> `(WHA) Western Hemispheric Affairs`

Will require a flush/reload @mjoyce91 of your local db (also gives you a chance to try the new create_demo_environment :) )