### PR TITLE
Deployment WSGI, environment files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,6 @@ missing_coverage.sh
 
 # MacOS
 .DS_Store
+
+#Environment setup script
+setup_environment.sh

--- a/EXAMPLE_setup_environment.sh
+++ b/EXAMPLE_setup_environment.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# The database to connect to
+export DATABASE_URL='postgres://username:password@hostname:5432/database_name'
+
+# The Django secret key
+export DJANGO_SECRET_KEY='secret_key'
+
+# Set the debug setting (True, true, or 1)
+# This should be set to False when in deployment
+export DJANGO_DEBUG=True
+
+# Deployment location
+# The directory where manage.py is located; requires the trailing slash
+export DEPLOYMENT_LOCATION='/var/www/talentmap/api/'

--- a/SETUP.md
+++ b/SETUP.md
@@ -47,7 +47,7 @@ If successful, the terminal prompt change to denote the active environment. To d
 The virtual environment has now been created. For further convenience, one can use the autoenv tool to automatically activate the virtual environment, but its usage falls outside the scope of this document.
 
 #### Environment Variables
-To run the Django server, the following environment variables must be set:
+To run the Django server, the following environment variables must be set (see `EXAMPLE_setup_environment.sh` for more):
 
 * `DJANGO_SECRET_KEY` - This should be any valid secret string. See the [Django documentation](https://docs.djangoproject.com/en/1.11/ref/settings/#std:setting-SECRET_KEY) for more information.
 * `DJANGO_DEBUG` - Set to `true` to run Django in Debug mode, which is helpful for development. It will default to `false`.
@@ -89,3 +89,6 @@ python manage.py runserver
 Viewing `localhost:8000` should serve you with Swagger documentation on the API.
 
 For production, it is recommended to set up uwsgi settings, which fall outside of the scope of this document.
+
+#### Deployment
+The application runs via WSGI in deployment. To support this, environment variables can be found in `EXAMPLE_setup_environment.sh` and should be modified to the particular deployment's specifications and saved as `setup_environment.sh` as this is where the application, when run in wsgi mode, will look for the environment variables.

--- a/talentmap_api/common/common_helpers.py
+++ b/talentmap_api/common/common_helpers.py
@@ -1,3 +1,5 @@
+import re
+
 from dateutil.relativedelta import relativedelta
 
 from django.contrib.auth.models import Group, Permission
@@ -211,3 +213,28 @@ def month_diff(start_date, end_date):
 
     r = relativedelta(end_date, start_date)
     return r.months + 12 * r.years
+
+
+def load_environment_script(file):
+    '''
+    Attempts to load environment data from the specified location
+
+    Args:
+        - file (String) - The path to the file
+
+    Return:
+        - dictionary (Object) - A dictionary of variable-key pairs
+    '''
+
+    environment_file = {}
+    try:
+        with open(file) as f:
+            for variable in re.finditer(r'export (.+)=(.+)', f.read()):
+                print(f"Found setup_environment.sh variable: {variable.group(1)}={variable.group(2)}")
+                # Store the variable, and strip any extra apostrophes or quotation marks
+                environment_file[variable.group(1)] = variable.group(2).replace("\'", "").replace("\"", "")
+    except:
+        print(f'TalentMAP: wsgi.py unable to load environment, does {file} exist?')
+        raise
+
+    return environment_file

--- a/talentmap_api/common/tests/test_common_helpers.py
+++ b/talentmap_api/common/tests/test_common_helpers.py
@@ -1,5 +1,7 @@
 import pytest
+import os
 
+from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.auth.models import User
 
@@ -7,7 +9,7 @@ from django.core.exceptions import PermissionDenied
 
 from model_mommy import mommy
 
-from talentmap_api.common.common_helpers import get_permission_by_name, get_group_by_name, in_group_or_403, has_permission_or_403
+from talentmap_api.common.common_helpers import get_permission_by_name, get_group_by_name, in_group_or_403, has_permission_or_403, load_environment_script
 from talentmap_api.position.models import Position
 
 
@@ -66,3 +68,18 @@ def test_in_group_or_403(authorized_user):
 
     # Should not raise an exception
     in_group_or_403(authorized_user, "test_group")
+
+
+@pytest.mark.django_db()
+def test_load_environment():
+    # Try to load a nonexistent file
+    with pytest.raises(Exception):
+        load_environment_script('i_dont_exist.sh.existential')
+
+    # Load the test environment script
+    env = load_environment_script(os.path.join(settings.BASE_DIR, 'talentmap_api', 'data', 'test_data', 'test_setup_environment.sh'))
+
+    assert env['DJANGO_DEBUG']
+    assert env['DATABASE_URL'] == 'postgres://username:password@hostname:5432/database_name'
+    assert env['DJANGO_SECRET_KEY'] == 'secret_key'
+    assert env['DEPLOYMENT_LOCATION'] == '/var/www/talentmap/api/'

--- a/talentmap_api/data/test_data/test_setup_environment.sh
+++ b/talentmap_api/data/test_data/test_setup_environment.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# The database to connect to
+export DATABASE_URL='postgres://username:password@hostname:5432/database_name'
+
+# The Django secret key
+export DJANGO_SECRET_KEY='secret_key'
+
+# Set the debug setting (True, true, or 1)
+# This should be set to False when in deployment
+export DJANGO_DEBUG=True
+
+# Deployment location
+# The directory where manage.py is located
+export DEPLOYMENT_LOCATION='/var/www/talentmap/api/'

--- a/talentmap_api/wsgi.py
+++ b/talentmap_api/wsgi.py
@@ -8,9 +8,23 @@ https://docs.djangoproject.com/en/1.11/howto/deployment/wsgi/
 """
 
 import os
+import sys
 
+from talentmap_api.common.common_helpers import load_environment_script
 from django.core.wsgi import get_wsgi_application
 
+
+environment = load_environment_script('../setup_environment.sh')
+
+
+# https support for the swagger documentation
+url_scheme = 'https'
+
+os.environ.setdefault("DJANGO_SECRET_KEY", environment["DJANGO_SECRET_KEY"])
+os.environ.setdefault("DATABASE_URL", environment["DATABASE_URL"])
+os.environ.setdefault("DJANGO_DEBUG", environment["DJANGO_DEBUG"])
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "talentmap_api.settings")
+sys.path.append(environment["DEPLOYMENT_LOCATION"])
+sys.path.append(f'{environment["DEPLOYMENT_LOCATION"]}talentmap_api/')
 
 application = get_wsgi_application()


### PR DESCRIPTION
- Sets up wsgi.py as it should be in deployment
- Creates `EXAMPLE_setup_environment.sh` script as a basis for deployment variable setups (and for prior to manual testing)
- Add `setup_environment.sh` to gitignore
- Add tests for helper function which loads environment variables from file