### PR TITLE
Update SOAP test to play nice with self signed certs

### DIFF
--- a/talentmap_api/common/common_helpers.py
+++ b/talentmap_api/common/common_helpers.py
@@ -273,7 +273,6 @@ def xml_etree_to_dict(tree):
 
     for child in tree.iterchildren():
         child_dict = xml_etree_to_dict(child)
-        print(child_dict)
         if len(child_dict.keys()) == 2:
             # We are a single tag with a child tag
             if len(child_dict["children"]) == 0:

--- a/talentmap_api/common/common_helpers.py
+++ b/talentmap_api/common/common_helpers.py
@@ -256,3 +256,32 @@ def month_diff(start_date, end_date):
 
     r = relativedelta(end_date, start_date)
     return r.months + 12 * r.years
+
+
+def xml_etree_to_dict(tree):
+    '''
+    Converts an XML etree into a dictionary.
+
+    Args:
+        - tree (Object) - XML Element tree
+
+    Returns:
+        - Dictionary
+    '''
+
+    dictionary = {"children": []}
+
+    for child in tree.iterchildren():
+        child_dict = xml_etree_to_dict(child)
+        print(child_dict)
+        if len(child_dict.keys()) == 2:
+            # We are a single tag with a child tag
+            if len(child_dict["children"]) == 0:
+                del child_dict["children"]
+            dictionary = {**dictionary, **child_dict}
+        else:
+            dictionary["children"].append(xml_etree_to_dict(child))
+
+    dictionary[tree.tag] = tree.text
+
+    return dictionary

--- a/talentmap_api/common/management/commands/soap_api_test.py
+++ b/talentmap_api/common/management/commands/soap_api_test.py
@@ -11,6 +11,7 @@ from zeep.transports import Transport
 
 from talentmap_api.common.common_helpers import xml_etree_to_dict
 
+
 class Command(BaseCommand):
     help = 'Tests the connection to the SOAP webservices'
     logger = logging.getLogger('console')

--- a/talentmap_api/common/management/commands/soap_api_test.py
+++ b/talentmap_api/common/management/commands/soap_api_test.py
@@ -27,7 +27,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         # Initialize transport layer
         session = Session()
-        print(options)
+
         if options['cert']:
             self.logger.info(f'Setting SSL verification cert to {options["cert"]}')
             session.verify = options['cert']

--- a/talentmap_api/common/management/commands/soap_api_test.py
+++ b/talentmap_api/common/management/commands/soap_api_test.py
@@ -6,6 +6,10 @@ import zeep
 
 import defusedxml.lxml as ET
 
+from requests import Session
+from zeep.transports import Transport
+
+from talentmap_api.common.common_helpers import xml_etree_to_dict
 
 class Command(BaseCommand):
     help = 'Tests the connection to the SOAP webservices'
@@ -19,11 +23,18 @@ class Command(BaseCommand):
         parser.add_argument('arguments', nargs='*', type=str, help="The arguments for the command")
 
     def handle(self, *args, **options):
+        # Initialize transport layer
+        session = Session()
+        # Uncomment the following line if we're verifying a self signed certificate
+        # session.verify = 'path_to_self_signed.cert'
+        session.verify = False
+        transport = Transport(session=session)
+
         # Get the WSDL location
         wsdl_location = os.environ.get('WSDL_LOCATION')
         self.logger.info(f'Initializing client with WSDL: {wsdl_location}')
 
-        client = zeep.Client(wsdl=wsdl_location)
+        client = zeep.Client(wsdl=wsdl_location, transport=transport)
 
         if not options['command']:
             self.logger.info('No command specified, dumping wsdl information')
@@ -32,9 +43,12 @@ class Command(BaseCommand):
 
         self.logger.info(f'Calling command {options["command"]} with parameters {options["arguments"]}')
         response = getattr(client.service, options['command'])(*options['arguments'])
+        dict_response = xml_etree_to_dict(response)
         self.logger.info(type(response))
         if not isinstance(response, str):
             response = ET.tostring(response, pretty_print=True)
 
         self.logger.info(f'SOAP call response:')
         self.logger.info(response.decode('unicode_escape'))
+
+        self.logger.info(f'Dictionary parsed response: {dict_response}')

--- a/talentmap_api/common/management/commands/soap_api_test.py
+++ b/talentmap_api/common/management/commands/soap_api_test.py
@@ -20,15 +20,20 @@ class Command(BaseCommand):
         super(Command, self).__init__(*args, **kwargs)
 
     def add_arguments(self, parser):
+        parser.add_argument('--cert', nargs='?', dest="cert", help='Location of the certificate for validating self-signed certificates')
         parser.add_argument('command', nargs='?', type=str, help="The command to run")
         parser.add_argument('arguments', nargs='*', type=str, help="The arguments for the command, as named pairs; i.e. USCity=Fairfax")
 
     def handle(self, *args, **options):
         # Initialize transport layer
         session = Session()
-        # Uncomment the following line if we're verifying a self signed certificate
-        # session.verify = 'path_to_self_signed.cert'
-        session.verify = False
+        print(options)
+        if options['cert']:
+            self.logger.info(f'Setting SSL verification cert to {options["cert"]}')
+            session.verify = options['cert']
+        else:
+            self.logger.info(f'Ignoring self-signed certification errors.')
+            session.verify = False
         transport = Transport(session=session)
 
         # Get the WSDL location

--- a/talentmap_api/common/management/commands/soap_api_test.py
+++ b/talentmap_api/common/management/commands/soap_api_test.py
@@ -20,7 +20,7 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument('command', nargs='?', type=str, help="The command to run")
-        parser.add_argument('arguments', nargs='*', type=str, help="The arguments for the command")
+        parser.add_argument('arguments', nargs='*', type=str, help="The arguments for the command, as named pairs; i.e. USCity=Fairfax")
 
     def handle(self, *args, **options):
         # Initialize transport layer
@@ -41,8 +41,9 @@ class Command(BaseCommand):
             client.wsdl.dump()
             return
 
-        self.logger.info(f'Calling command {options["command"]} with parameters {options["arguments"]}')
-        response = getattr(client.service, options['command'])(*options['arguments'])
+        arguments = {x.split('=')[0]: x.split('=')[1] for x in options["arguments"]}
+        self.logger.info(f'Calling command {options["command"]} with parameters {arguments}')
+        response = getattr(client.service, options['command'])(**arguments)
         dict_response = xml_etree_to_dict(response)
         self.logger.info(type(response))
         if not isinstance(response, str):

--- a/talentmap_api/settings.py
+++ b/talentmap_api/settings.py
@@ -164,7 +164,7 @@ if ENABLE_SAML2:
         'xmlsec_binary': os.environ.get('SAML2_XMLSEC1_PATH'),
 
         # your entity id, usually your subdomain plus the url to the metadata view
-        'entityid': f"os.environ.get('SAML2_ENTITY_ID')saml2/metadata/",
+        'entityid': f"{os.environ.get('SAML2_ENTITY_ID')}saml2/metadata/",
 
         # directory with attribute mapping
         'attribute_map_dir': os.path.join(BASE_DIR, 'talentmap_api', 'saml2', 'attribute_maps'),


### PR DESCRIPTION
Suitable for Thursday redeploy; no new libraries required.

`python manage.py soap_api_test` will return a WSDL inspection (listing callable services) - it should show something like this:

`IPMSDataWebService(RequestorID: xsd:string, Action: xsd:string, RequestName: xsd:string, Version: xsd:string, InputParameters: xsd:string, MaximumOutputRows: xsd:string, PaginationStartKey: xsd:string, DataFormat: xsd:string) -> IPMSDataWebServiceResult: {_value_1: ANY}`

`python manage.py soap_api_test IPMSDataWebService RequestorID=TalentMAP Action=GET RequestName=skill Version=0.01 DataFormat=XML` will call "IPMSDataWebService" should return some skills. We may need to pass `InputParameters=<![CDATA[<skills><skill></skill></skills>]]>` but I want to hold off on that.

Should be enough to poke around and make sure the connection is working as intended. When you're testing try and poke around to see how MaxOutputRows / PaginationStartKey work (`python manage.py soap_api_test IPMSDataWebService . . . MaxOutputRows=5 PaginationStartKey=1` and then 2, etc...)