### PR TITLE
Token view endpoint

### DIFF
--- a/talentmap_api/common/tokens/serializers.py
+++ b/talentmap_api/common/tokens/serializers.py
@@ -1,0 +1,9 @@
+from talentmap_api.common.serializers import PrefetchedSerializer
+from rest_framework.authtoken.models import Token
+
+
+class TokenSerializer(PrefetchedSerializer):
+
+    class Meta:
+        model = Token
+        fields = "__all__"

--- a/talentmap_api/common/tokens/urls.py
+++ b/talentmap_api/common/tokens/urls.py
@@ -1,0 +1,8 @@
+from django.conf.urls import url
+
+from talentmap_api.common.tokens import views
+from talentmap_api.common.urls import get_retrieve
+
+urlpatterns = [
+    url(r'^$', views.TokenView.as_view({**get_retrieve}), name='common.Token-retrieve'),
+]

--- a/talentmap_api/common/tokens/views.py
+++ b/talentmap_api/common/tokens/views.py
@@ -1,5 +1,3 @@
-from django.shortcuts import get_object_or_404
-
 from rest_framework.viewsets import GenericViewSet
 from rest_framework import mixins
 
@@ -21,4 +19,4 @@ class TokenView(mixins.RetrieveModelMixin,
     permission_classes = (IsAuthenticated,)
 
     def get_object(self):
-        return get_object_or_404(Token, user=self.request.user)
+        return Token.objects.get_or_create(user=self.request.user)

--- a/talentmap_api/common/tokens/views.py
+++ b/talentmap_api/common/tokens/views.py
@@ -1,0 +1,24 @@
+from django.shortcuts import get_object_or_404
+
+from rest_framework.viewsets import GenericViewSet
+from rest_framework import mixins
+
+from rest_framework.permissions import IsAuthenticated
+
+from rest_framework.authtoken.models import Token
+
+from talentmap_api.common.tokens.serializers import TokenSerializer
+
+
+class TokenView(mixins.RetrieveModelMixin,
+                GenericViewSet):
+    """
+    retrieve:
+    Return the current user's authentication token
+    """
+
+    serializer_class = TokenSerializer
+    permission_classes = (IsAuthenticated,)
+
+    def get_object(self):
+        return get_object_or_404(Token, user=self.request.user)

--- a/talentmap_api/common/tokens/views.py
+++ b/talentmap_api/common/tokens/views.py
@@ -19,4 +19,4 @@ class TokenView(mixins.RetrieveModelMixin,
     permission_classes = (IsAuthenticated,)
 
     def get_object(self):
-        return Token.objects.get_or_create(user=self.request.user)
+        return Token.objects.get_or_create(user=self.request.user)[0]  # Throw away created flag

--- a/talentmap_api/urls.py
+++ b/talentmap_api/urls.py
@@ -68,8 +68,9 @@ urlpatterns = [
 
 # Auth patterns
 urlpatterns += [
-    url(r'^api/v1/accounts/token/', auth_views.obtain_expiring_auth_token),
+    url(r'^api/v1/accounts/token/$', auth_views.obtain_expiring_auth_token),
     url(r'^api/v1/accounts/', include('rest_framework.urls')),
+    url(r'^api/v1/accounts/token/view/$', include('talentmap_api.common.tokens.urls')),
 ]
 
 if settings.ENABLE_SAML2:  # pragma: no cover


### PR DESCRIPTION
- Supports ADFS login for frontend
- Creates a token for a user if they don't have one but are authenticated (i.e. logged in via ADFS)