### PR TITLE
Organization groups m2m in

### DIFF
--- a/talentmap_api/common/filters.py
+++ b/talentmap_api/common/filters.py
@@ -5,6 +5,8 @@ from django.contrib.postgres.search import SearchVector
 from rest_framework_filters.backends import DjangoFilterBackend
 
 from rest_framework import filters
+import rest_framework_filters as drff_filters
+
 from django.core.exceptions import FieldDoesNotExist
 
 # Common filters for string-type objects
@@ -54,6 +56,13 @@ class RelatedOrderingFilter(filters.OrderingFilter):
     def remove_invalid_fields(self, queryset, fields, ordering, view):
         return [term for term in fields
                 if self.is_valid_field(queryset.model, term.lstrip('-'))]
+
+
+class NumberInFilter(drff_filters.BaseInFilter, drff_filters.NumberFilter):
+    '''
+    Combines the in and number filter to support M2M in filtering
+    '''
+    pass
 
 
 def negate_boolean_filter(lookup_expr):

--- a/talentmap_api/organization/filters.py
+++ b/talentmap_api/organization/filters.py
@@ -1,7 +1,7 @@
 import rest_framework_filters as filters
 
 from talentmap_api.organization.models import Organization, Post, TourOfDuty, Location, Country, OrganizationGroup
-from talentmap_api.common.filters import multi_field_filter, negate_boolean_filter, full_text_search
+from talentmap_api.common.filters import multi_field_filter, negate_boolean_filter, full_text_search, NumberInFilter
 from talentmap_api.common.filters import ALL_TEXT_LOOKUPS, INTEGER_LOOKUPS, FOREIGN_KEY_LOOKUPS
 
 
@@ -10,6 +10,8 @@ class OrganizationFilter(filters.FilterSet):
     parent_organization = filters.RelatedFilter('talentmap_api.organization.filters.OrganizationFilter', name='parent_organization', queryset=Organization.objects.all())
     groups = filters.RelatedFilter('talentmap_api.organization.filters.OrganizationGroupFilter', name='groups', queryset=OrganizationGroup.objects.all())
     location = filters.RelatedFilter('talentmap_api.organization.filters.LocationFilter', name='location', queryset=Location.objects.all())
+
+    has_groups = NumberInFilter(name='groups', lookup_expr='in')
 
     # Name here must be a valid field, but it is ignored when overriden by the method parameter
     is_available = filters.BooleanFilter(name="bureau_positions", method=multi_field_filter(fields=["bureau_positions", "organization_positions"], lookup_expr="isnull", exclude=True))

--- a/talentmap_api/position/filters.py
+++ b/talentmap_api/position/filters.py
@@ -14,7 +14,7 @@ from talentmap_api.language.models import Qualification
 from talentmap_api.organization.filters import OrganizationFilter, PostFilter, TourOfDutyFilter
 from talentmap_api.organization.models import Organization, Post, TourOfDuty
 
-from talentmap_api.common.filters import full_text_search, ALL_TEXT_LOOKUPS, DATE_LOOKUPS, FOREIGN_KEY_LOOKUPS, INTEGER_LOOKUPS
+from talentmap_api.common.filters import full_text_search, ALL_TEXT_LOOKUPS, DATE_LOOKUPS, FOREIGN_KEY_LOOKUPS, INTEGER_LOOKUPS, NumberInFilter
 
 
 class GradeFilter(filters.FilterSet):
@@ -95,6 +95,7 @@ class PositionFilter(filters.FilterSet):
 
     is_domestic = filters.BooleanFilter(name="is_overseas", lookup_expr="exact", exclude=True)
     is_highlighted = filters.BooleanFilter(name="highlighted_by_org", lookup_expr="isnull", exclude=True)
+    org_has_groups = NumberInFilter(name='organization__groups', lookup_expr='in')
 
     # Full text search across multiple fields
     q = filters.CharFilter(name="position_number", method=full_text_search(


### PR DESCRIPTION
Fixes an issue @mjoyce91 was having

When using `__in` on an M2M foreign key it was treating it like a string. This adds `?has_groups` to support m2m filtering with many id's. `?has_groups=1,2,3` etc.

Can be combined `?has_groups=3,1&groups__name__icontains=congo` with other groups filters.

**NOTE** On the positions endpoint, this filter is `?org_has_groups` 