### PR TITLE
Change ensure_date

### DIFF
--- a/talentmap_api/common/common_helpers.py
+++ b/talentmap_api/common/common_helpers.py
@@ -171,7 +171,7 @@ def ensure_date(date, utc_offset=0):
     if not date:
         return None
     elif isinstance(date, str):
-        return parser.parse(date).astimezone(datetime.timezone(datetime.timedelta(hours=utc_offset)))
+        return parser.parse(date) - datetime.timedelta(hours=utc_offset)
     elif isinstance(date, datetime.date):
         return date.astimezone(datetime.timezone(datetime.timedelta(hours=utc_offset)))
     else:

--- a/talentmap_api/common/common_helpers.py
+++ b/talentmap_api/common/common_helpers.py
@@ -171,7 +171,7 @@ def ensure_date(date, utc_offset=0):
     if not date:
         return None
     elif isinstance(date, str):
-        return parser.parse(date) - datetime.timedelta(hours=utc_offset)
+        return parser.parse(date).astimezone(datetime.timezone.utc) - datetime.timedelta(hours=utc_offset)
     elif isinstance(date, datetime.date):
         return date.astimezone(datetime.timezone(datetime.timedelta(hours=utc_offset)))
     else:

--- a/talentmap_api/common/tests/test_common_helpers.py
+++ b/talentmap_api/common/tests/test_common_helpers.py
@@ -19,14 +19,9 @@ def test_ensure_date():
     with pytest.raises(Exception, match="Parameter must be a date object or string"):
         ensure_date(201225123)
 
-    date = parser.parse("1000-01-01").astimezone(datetime.timezone.utc)
+    date = parser.parse("1000-01-01T00:00:00-05:00")
 
     # Now check it
-    assert ensure_date("1000-01-01") == date
-    assert ensure_date(date) == date
-
-    date = parser.parse("1000-01-01").astimezone(datetime.timezone(datetime.timedelta(hours=-5)))
-
     assert ensure_date("1000-01-01", utc_offset=-5) == date
 
 

--- a/talentmap_api/integrations/synchronization_helpers.py
+++ b/talentmap_api/integrations/synchronization_helpers.py
@@ -469,10 +469,10 @@ def mode_cycles(last_updated_date=None):
         # Find the dates for this cycle
         for date in xml_dict["children"]:
             if date["DATA_TYPE"] == "CYCLE":
-                instance.cycle_start_date = ensure_date(date["BEGIN_DATE"])
-                instance.cycle_end_date = ensure_date(date["END_DATE"])
+                instance.cycle_start_date = ensure_date(date["BEGIN_DATE"], utc_offset=-5)
+                instance.cycle_end_date = ensure_date(date["END_DATE"], utc_offset=-5)
             elif date["DATA_TYPE"] == "BIDDUE":
-                instance.cycle_deadline_date = ensure_date(date["BEGIN_DATE"])
+                instance.cycle_deadline_date = ensure_date(date["BEGIN_DATE"], utc_offset=-5)
         if updated:
             instance.save()
 
@@ -525,8 +525,8 @@ def mode_cycle_positions(last_updated_date=None):
             bidding_status.status_code = data["STATUS_CODE"]
             bidding_status.status = data["STATUS"]
             bidding_status.save()
-            position.effective_date = ensure_date(data["DATE_UPDATED"])
-            position.posted_date = ensure_date(data["CP_POST_DT"])
+            position.effective_date = ensure_date(data["DATE_UPDATED"], utc_offset=-5)
+            position.posted_date = ensure_date(data["CP_POST_DT"], utc_offset=-5)
             position.save()
             if "TED" in data.keys():
                 ted = ensure_date(data["TED"], utc_offset=-5)


### PR DESCRIPTION
Change ensure_date to add the utc_offset, which will properly allow for the incoming date to convert to UTC rather than offsetting after the fact, which was leading to mis-matched dates

Update date SOAP syncs to use utc_offset